### PR TITLE
Add ssh public key data into clusterDefintion. Use acs-engine deploy

### DIFF
--- a/Deployment.md
+++ b/Deployment.md
@@ -27,8 +27,7 @@ Open [globalVariables.prod.sh](deployment/globalVariables.prod.sh) and enter val
 
 A private / public certificate key pair is required to setup the k8 cluster so client dev and ops engineers can connect to the cluster after deployment.
 
-- Generate new [SSH keys](https://github.com/Azure/acs-engine/blob/master/docs/ssh.md#ssh-key-generation/) and save it in /deployment as `cluster_rsa.pub` and `cluster_rsa`
-- Update `clusterDefinition.json` with the public key contained in `cluster_rsa.pub`. `keyData` must contain the public portion of an SSH key (e.g. 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA....')
+- Generate new [SSH keys](https://github.com/Azure/acs-engine/blob/master/docs/ssh.md#ssh-key-generation/) and save it in /deployment as `cluster_rsa.pub` and `cluster_rsa`. The public portion of the SSH key will be added in `clusterDefinition.json` later.
 
 #### Step 3: Execute [inception.sh](deployment/inception.sh)
 

--- a/deployment/deployCluster.sh
+++ b/deployment/deployCluster.sh
@@ -62,6 +62,7 @@ az keyvault set-policy --secret-permissions get --certificate-permissions get --
 ## -------
 ## create kubernetes cluster
 DNS_PREFIX=$CLUSTER_NAME
+SSH_PUB_KEY_DATA=$(<cluster_rsa.pub)
 
 # prepare the cluster deployment file for ACS Engine
 echo Starting update of cluster definition json file
@@ -69,34 +70,27 @@ CLUSTER_DEFINITION=$(<clusterDefinition.json)
 CLUSTER_DEFINITION=$(jq --arg id $ACS_SERVICE_PRINCIPAL_ID '.properties.servicePrincipalProfile.clientId=$id' <<< "$CLUSTER_DEFINITION")
 CLUSTER_DEFINITION=$(jq --arg secret $ACS_SERVICE_PRINCIPAL_PASSWORD '.properties.servicePrincipalProfile.secret=$secret' <<< "$CLUSTER_DEFINITION")
 CLUSTER_DEFINITION=$(jq --arg dnsPrefix $DNS_PREFIX '.properties.masterProfile.dnsPrefix=$dnsPrefix' <<< "$CLUSTER_DEFINITION")
+CLUSTER_DEFINITION=$(jq --arg ssh_pub_key_data "$SSH_PUB_KEY_DATA" '.properties.linuxProfile.ssh.publicKeys[0].keyData=$ssh_pub_key_data' <<< "$CLUSTER_DEFINITION")
 echo $CLUSTER_DEFINITION > clusterDefinition.temp.json
 echo Updated cluster definition json file
 
-# generate the ARM template
-echo Starting generation of ARM template
-acs-engine generate ./clusterDefinition.temp.json
-echo Completed generation of ARM template
-
-# deploy the ARM template
-echo Starting deployment of ARM template
-az group deployment create \
-    --name acs-engine-cluster \
-    --resource-group $RESOURCE_GROUP \
-    --template-file ./_output/$DNS_PREFIX/azuredeploy.json \
-    --parameters ./_output/$DNS_PREFIX/azuredeploy.parameters.json
-echo Completed deployment of ARM template
+# deploy Kubernetes cluster with acs-engine
+echo Starting deployment of Kubernetes cluster using acs-engine
+acs-engine deploy \
+    --subscription-id $AZURE_SUBSCRIPTION_ID \
+    --resource-group $RESOURCE_GROUP  \
+    --location $AZURE_LOCATION \
+    --api-model ./clusterDefinition.temp.json
+echo Completed deployment of Kubernetes cluster
 
 echo Starting to clean up ARM template resources
 rm ./clusterDefinition.temp.json
 
-
 ## -------
 ## Download Kubernetes Credentials and show cluster information
 chmod 700 cluster_rsa
-echo "----- You will need to enter the certificate password after the next command before it times out -----"
-sleep 15 # give the user time to prepare to enter the password
-scp -i ./cluster_rsa azureuser@$DNS_PREFIX.$AZURE_LOCATION.cloudapp.azure.com:.kube/config .
-export KUBECONFIG=`pwd`/config
+KUBECONFIG=`pwd`/_output/$CLUSTER_NAME/kubeconfig/kubeconfig.$AZURE_LOCATION.json
+export KUBECONFIG
 kubectl config use-context $CLUSTER_NAME
 kubectl version
 kubectl cluster-info


### PR DESCRIPTION
- Add ssh public key data into clusterDefinition.
- Use acs-engine deploy as it runs both acs-engine generate and az group deployment.
- Use local generate kubeconfig instead of scp