### PR TITLE
Fix script issues

### DIFF
--- a/deployment/createMtSvc.sh
+++ b/deployment/createMtSvc.sh
@@ -13,14 +13,14 @@ set -e # stop script execution on failure
 set -x
 
 MT_SERVICE_PRINCIPAL_NAME=$PROJECT_NAME-mt-svc
-az ad sp delete --id http://$MT_SERVICE_PRINCIPAL_NAME
+! az ad sp delete --id http://$MT_SERVICE_PRINCIPAL_NAME
 MT_SERVICE_PRINCIPAL_PASSWORD=`az ad sp create-for-rbac --name $MT_SERVICE_PRINCIPAL_NAME --role=Reader --scopes="/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$COMMON_RESOURCE_GROUP" --query password -o tsv`
 
 az keyvault secret set --name mt-aad-password --vault-name $K8_DEPLOYMENT_KEYVAULT_NAME --description "used by middle tier to access all Azure resources" --value $MT_SERVICE_PRINCIPAL_PASSWORD --query id
 
 # MT specific secrets
 MT_KEYVAULT_NAME=$PROJECT_NAME-mt-svc-kv
-az keyvault delete --name $MT_KEYVAULT_NAME --resource-group $COMMON_RESOURCE_GROUP
+! az keyvault delete --name $MT_KEYVAULT_NAME --resource-group $COMMON_RESOURCE_GROUP
 az keyvault create --name $MT_KEYVAULT_NAME --resource-group $COMMON_RESOURCE_GROUP --location $AZURE_LOCATION
 
 az keyvault set-policy --secret-permissions get --resource-group $COMMON_RESOURCE_GROUP --name $MT_KEYVAULT_NAME --spn http://$MT_SERVICE_PRINCIPAL_NAME

--- a/deployment/deployCluster.sh
+++ b/deployment/deployCluster.sh
@@ -102,7 +102,7 @@ rm ./clusterDefinition.temp.json
 ## -------
 ## Set Kubernetes Credentials and show cluster information
 
-KUBE_RESOURCES_PATH=_output/$CLUSTER_NAME
+KUBE_RESOURCES_PATH=$ACS_OUTPUT_DIR
 KUBE_USER=$CLUSTER_NAME-admin
 
 # Set cluster

--- a/deployment/deployContainerRegistry.sh
+++ b/deployment/deployContainerRegistry.sh
@@ -18,6 +18,6 @@ SKU=Basic # Basic, Premium, Standard
 
 ## -------
 ## create acr
-az acr delete -n $AZURE_CONTAINER_REGISTRY_NAME
+! az acr delete -n $AZURE_CONTAINER_REGISTRY_NAME
 az acr create -n $AZURE_CONTAINER_REGISTRY_NAME -g $COMMON_RESOURCE_GROUP --sku $SKU -l $AZURE_LOCATION --admin-enabled true
 export AZURE_CONTAINER_REGISTRY_NAME

--- a/deployment/inception.sh
+++ b/deployment/inception.sh
@@ -20,7 +20,7 @@ az account set --subscription $AZURE_SUBSCRIPTION_ID
 
 ## -------
 # Make sure DNS name is available for Azure Traffic Manager, if not, exit
-if [ az network traffic-manager profile check-dns --name $PROJECT_NAME.$PUBLIC_DOMAIN_NAME_SUFFIX --query nameAvailable = "false" ]; then
+if [ $(az network traffic-manager profile check-dns --name $PROJECT_NAME.$PUBLIC_DOMAIN_NAME_SUFFIX --query nameAvailable) = "false" ]; then
     echo "!!!DNS name $PROJECT_NAME is not available in Azure Traffic Manager - exiting!!!"
     exit 1
 fi


### PR DESCRIPTION
Lines 16, 23 of `createMtSvc.sh` and line 21 of `deployContainerRegistry.sh` on the first run should always fail, sending back a return code and exiting early because of the `set -e` at the top.

The `if` is currently being parsed incorrectly, this should also fix it.

`deployCluster.sh` looks like it was not updated the last time they change the output dir location.